### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -1,4 +1,6 @@
 name: Code Quality Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vintagesquid/papirsarkany/security/code-scanning/5](https://github.com/vintagesquid/papirsarkany/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow that restricts the permissions of the GITHUB_TOKEN. The best way is to add it at the top level of the workflow YAML file, so it applies to all jobs unless overridden. For this workflow, which only requires reading the repository contents, set `permissions: contents: read` at the root (just after the name and before the `on` or `jobs` key). No other permissions are needed for the steps shown. You do not need to change anything in the steps themselves.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
